### PR TITLE
Modify podspec to correctly reference Firebase Frameworks

### DIFF
--- a/FoobarLib.podspec
+++ b/FoobarLib.podspec
@@ -12,16 +12,36 @@ Pod::Spec.new do |s|
 
   s.source_files = [
     'FoobarLib/Classes/**/*',
-#    'FoobarLib/Frameworks/Firebase/Firebase.h',
-  ]
-  s.vendored_frameworks = [
-#    'FoobarLib/Frameworks/Firebase/Analytics/*.framework',
   ]
 
-  s.dependency 'Firebase'
+  # Specify what libraries this depends on.
+  s.libraries = [
+    'c++', # FirebaseAnalytics.
+    'icucore', # FirebaseDatabase.
+    'sqlite3', # FirebaseAnalytics.
+    'z', # FirebaseAnalytics.
+  ]
+
+  # Specify what frameworks this depends on.
+  s.frameworks = [
+    'AddressBook', # FirebaseAnalytics.
+    'AdSupport', # FirebaseAnalytics.
+    'CFNetwork', # FirebaseDatabase.
+    'SafariServices', # FirebaseAnalytics.
+    'Security', # FirebaseAnalytics, FirebaseAuth, FirebaseDatabase.
+    'StoreKit', # FirebaseAnalytics.
+    'SystemConfiguration', # FirebaseAnalytics, FirebaseDatabase.
+  ]
+
+  s.vendored_frameworks = [
+    'FoobarLib/Frameworks/Firebase/Analytics/*.framework',
+    'FoobarLib/Frameworks/Firebase/Auth/*.framework',
+    'FoobarLib/Frameworks/Firebase/Database/*.framework',
+    'FoobarLib/Frameworks/Firebase/Messaging/*.framework',
+  ]
 
   s.pod_target_xcconfig = {
-#    'OTHER_LDFLAGS' => '$(inherited) -ObjC',
+    'OTHER_LDFLAGS' => '$(inherited) -ObjC',
 #    'FRAMEWORK_SEARCH_PATHS' => '$(inherited) $(PODS_ROOT)/**',
 #    'USER_HEADER_SEARCH_PATHS' => '$(PODS_ROOT)/FirebaseCore.framework/Modules',
 #    'SWIFT_INCLUDE_PATHS' => '$(PODS_ROOT)/FirebaseCore.framework/Modules',

--- a/FoobarLib/Classes/Foobar.swift
+++ b/FoobarLib/Classes/Foobar.swift
@@ -1,1 +1,1 @@
-import Firebase
+import FirebaseDatabase


### PR DESCRIPTION
With these changes, a project referencing this pod builds for me.

A few things worth noting:
* I never could get just `import Firebase` to work. You have to reference each framework specifically (i.e., `import FirebaseDatabase`). It's a minor annoyance, but I didn't find it to be a big enough to deal to spend more hours trying to figure out why.
* These changes _only_ add support for the Analytics, Database, and Messaging modules. This is because those are the only ones I've used and can verify. If you need others, that's up to you! :)

To add other modules:
1. Add the module to vendored_frameworks, e.g.: `'FoobarLib/Frameworks/Firebase/MODULE/*.framework'`.
2. Find the desired framework on cocoapods.org, such as [FirebaseAnalytics](https://cocoapods.org/pods/FirebaseAnalytics).
3. Click [See Podspec](https://github.com/CocoaPods/Specs/blob/master/Specs/e/2/1/FirebaseAnalytics/3.6.0/FirebaseAnalytics.podspec.json) at bottom right of the page.
4. Ensure any `frameworks` and `libraries` listed there are also listed in the `FoobarLib.podspec`.
5. Cross you fingers and hope it all works out!